### PR TITLE
Adjust suppressed UI

### DIFF
--- a/src/customization/customizations.ts
+++ b/src/customization/customizations.ts
@@ -3,4 +3,5 @@ export const CUSTOMIZATIONS: Record<string, string | number | boolean> = {
     hideIcon: true,
     disableMarkAsFixed: true,
     disableFixes: true,
+    excludeSuppressedResults: true,
 };

--- a/src/customization/customizations.ts
+++ b/src/customization/customizations.ts
@@ -1,4 +1,6 @@
-export const CUSTOMIZATIONS: Record<string, string | number | boolean> = {
+export type CUSTOMIZATION_VALUES = string | number | boolean;
+
+export const CUSTOMIZATIONS: Record<string, CUSTOMIZATION_VALUES> = {
     panelTitle: 'Violation',
     hideIcon: true,
     disableMarkAsFixed: true,

--- a/src/customization/index.ts
+++ b/src/customization/index.ts
@@ -1,5 +1,5 @@
-import { CUSTOMIZATIONS } from './customizations';
+import { CUSTOMIZATIONS, CUSTOMIZATION_VALUES } from './customizations';
 
-export function getCustomization<T_DATA>(name: string, defaultValue: T_DATA): T_DATA {
+export function getCustomization<T_DATA extends CUSTOMIZATION_VALUES>(name: string, defaultValue: T_DATA): T_DATA {
     return (CUSTOMIZATIONS[name] ?? defaultValue) as T_DATA;
 }

--- a/src/panel/resultTableStore.ts
+++ b/src/panel/resultTableStore.ts
@@ -6,6 +6,7 @@ import { Result } from 'sarif';
 import { Visibility } from '../shared';
 import { IndexStore } from './indexStore';
 import { Column, Row, TableStore } from './tableStore';
+import { getCustomization } from '../customization';
 
 export class ResultTableStore<G> extends TableStore<Result, G> {
     constructor(
@@ -77,7 +78,8 @@ export class ResultTableStore<G> extends TableStore<Result, G> {
     }
 
     public isLineThrough(result: Result): boolean {
-        return this.resultsSource.resultsFixed.includes(JSON.stringify(result._id));
+        return this.resultsSource.resultsFixed.includes(JSON.stringify(result._id)) ||
+            (getCustomization<boolean>('excludeSuppressedResults', false) && result._suppression === 'suppressed');
     }
 
     public menuContext(result: Result): Record<string, string> | undefined {


### PR DESCRIPTION
This PR fixes https://github.com/kubeshop/vscode-monokle/issues/78.

Suppressed violations are now crossed-out in the Violations panel, no longer highlighted in the editor or shown in problems panel.

![image](https://github.com/kubeshop/vscode-sarif/assets/1061942/6775cff3-42b4-46c4-bb66-386fdb40685b)

## Changes

- As above.

## Fixes

- As above.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
