### PR TITLE
feat: introduce configurable loadLogs API method

### DIFF
--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -152,6 +152,18 @@ export async function activate(context: ExtensionContext): Promise<Api> {
 
     // API
     const api = {
+        async loadLogs(logs: Uri[], options?: Record<string, boolean>, cancellationToken?: CancellationToken) {
+            watcher.add(logs.map(log => log.fsPath));
+            store.logs.push(...await loadLogs(logs, cancellationToken));
+
+            if (cancellationToken?.isCancellationRequested) {
+                return;
+            }
+
+            if (options?.openPanel && store.results.length || options?.forceOpenPanel) {
+                return panel.show();
+            }
+        },
         async openLogs(logs: Uri[], _options?: unknown, cancellationToken?: CancellationToken) {
             watcher.add(logs.map(log => log.fsPath));
             store.logs.push(...await loadLogs(logs, cancellationToken));


### PR DESCRIPTION
This PR introduces configurable `loadLogs` API method (this API is exposed by the extension) so from Monokle extension we can control when SARIF panel is shown. This method is just slightly modified `openLogs` but I wanted to keep it separate for clarity.

## Changes

- As above.

## Fixes

- As above.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
