### PR TITLE
Allow selecting result on panel open

### DIFF
--- a/src/extension/index.d.ts
+++ b/src/extension/index.d.ts
@@ -2,6 +2,13 @@
 // Licensed under the MIT License.
 
 import { CancellationToken, Uri } from 'vscode';
+import { ResultId } from '../shared';
+
+export type LoadLogsOptions = {
+    openPanel?: boolean;
+    forceOpenPanel?: boolean;
+    resultId?: ResultId;
+}
 
 /**
  * This API is consumed by other extensions. Breaking changes to this API must
@@ -12,7 +19,7 @@ export interface Api {
      * Note: If a log has been modified after open was opened, a close and re-open will be required to "refresh" that log.
      * @param logs An array of Uris to open.
      */
-    loadLogs(logs: Uri[], options?: Record<string, boolean>): Promise<void>;
+    loadLogs(logs: Uri[], options?: LoadLogsOptions): Promise<void>;
     openLogs(logs: Uri[]): Promise<void>;
     closeLogs(logs: Uri[], _options?: unknown, cancellationToken?: CancellationToken): Promise<void>;
     closeAllLogs(): Promise<void>;

--- a/src/panel/index.tsx
+++ b/src/panel/index.tsx
@@ -11,7 +11,7 @@ import '../shared/extension';
 import { Details } from './details';
 import { FilterKeywordContext } from './filterKeywordContext';
 import './index.scss';
-import { IndexStore, postLoad, postRefresh } from './indexStore';
+import { IndexStore, postLoad, postLoaded, postRefresh } from './indexStore';
 import { ResultTable } from './resultTable';
 import { RowItem } from './tableStore';
 import { Checkrow, Icon, Popover, ResizeHandle, Tab, TabPanel } from './widgets';
@@ -132,6 +132,12 @@ export { DetailsLayouts } from './details.layouts';
     componentDidMount() {
         addEventListener('message', this.props.store.onMessage);
         postLoad();
+    }
+
+    componentDidUpdate(prevProps: Readonly<{ store: IndexStore }>): void {
+        setTimeout(() => {
+            postLoaded();
+        }, 0);
     }
 
     componentWillUnmount() {

--- a/src/panel/indexStore.ts
+++ b/src/panel/indexStore.ts
@@ -149,6 +149,10 @@ export async function postLoad() {
     await vscode.postMessage({ command: 'load' });
 }
 
+export async function postLoaded() {
+    await vscode.postMessage({ command: 'loaded' });
+}
+
 export async function postSelectArtifact(result: Result, ploc?: PhysicalLocation) {
     // If this panel is not active, then any selection change did not originate from (a user's action) here.
     // It must have originated from (a user's action in) the editor, which then sent a message here.

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -240,5 +240,5 @@ export const filtersColumn: Record<string, Record<string, Visibility>> = {
     },
 };
 
-export type CommandPanelToExtension = 'load' | 'open' | 'closeLog' | 'closeAllLogs' | 'select' | 'selectLog' | 'setState' | 'refresh' | 'removeResultFixed';
+export type CommandPanelToExtension = 'load' | 'loaded' | 'open' | 'closeLog' | 'closeAllLogs' | 'select' | 'selectLog' | 'setState' | 'refresh' | 'removeResultFixed';
 export type CommandExtensionToPanel = 'select' | 'spliceLogs' | 'spliceResultsFixed' | 'setBanner';


### PR DESCRIPTION
This PR allows to pass result id with `show panel` command so it's selected when panel opens.

Since the result is searched in panel itself (webview), when `select` post message is send right after `show` the results are still not propagated resulting in error (not selecting). I added additional `loaded` event which is send on panel component update to notify extension code that results were loaded.

This is required for https://github.com/kubeshop/vscode-monokle/pull/90.

## Changes

- As above.

## Fixes

- None.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
