### PR TITLE
feat: add support for under review suppressions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "files.exclude": {
+        "**/out": true,
         "**/dist": true,
         "**/node_modules": true,
         "common/temp": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
     "files.exclude": {
-        "**/out": true,
         "**/dist": true,
         "**/node_modules": true,
         "common/temp": true,

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@
             },
             Suppression: {
                 'Not Suppressed': true,
+                'Under Review': true,
                 'Suppressed': false,
             },
         },

--- a/samples/demoSarif.json
+++ b/samples/demoSarif.json
@@ -26,6 +26,50 @@
                             }
                         }
                     ]
+                },
+                {
+                    "ruleId": "DEMO02",
+                    "message": {
+                        "text": "A result 2"
+                    },
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "file:///foo/baz/bar.txt"
+                                }
+                            }
+                        }
+                    ],
+                    "suppressions": [
+                        {
+                            "guid": "id2",
+                            "kind": "external",
+                            "status": "underReview"
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "DEMO03",
+                    "message": {
+                        "text": "Result 3"
+                    },
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "file:///foo/baz/bar.txt"
+                                }
+                            }
+                        }
+                    ],
+                    "suppressions": [
+                        {
+                            "guid": "id3",
+                            "kind": "external",
+                            "status": "suppressed"
+                        }
+                    ]
                 }
             ]
         }

--- a/src/extension/panel.ts
+++ b/src/extension/panel.ts
@@ -72,10 +72,13 @@ export class Panel {
         const srcPanel = Uri.file(`${context.extensionPath}/out/panel.js`);
         const srcInit = Uri.file(`${context.extensionPath}/out/init.js`);
         const defaultState = {
-            version: 0,
+            version: 1,
             filtersRow,
             filtersColumn,
         };
+
+        const savedState = Store.globalState.get('view', defaultState);
+        const latestState = !savedState || savedState.version !== defaultState.version ? defaultState : savedState;
 
         // JSON.stringify emits double quotes. To not conflict, certain attribute values use single quotes.
         webview.html = `<!DOCTYPE html>
@@ -90,7 +93,7 @@ export class Panel {
                     script-src  vscode-resource:;
                     style-src   vscode-resource: 'unsafe-inline';
                     ">
-                <meta name="storeState"        content='${JSON.stringify(Store.globalState.get('view', defaultState))}'>
+                <meta name="storeState"        content='${JSON.stringify(latestState)}'>
                 <meta name="storeWorkspaceUri" content="${workspace.workspaceFolders?.[0]?.uri.toString() ?? ''}">
                 <meta name="storeBanner"       content='${store.banner}'>
                 <style>

--- a/src/panel/resultTableStore.spec.ts
+++ b/src/panel/resultTableStore.spec.ts
@@ -26,13 +26,13 @@ describe('ResultTableStore', () => {
         assert.deepStrictEqual(resultTableStore.columns.map((col) => col.name), ['Line', 'File', 'Message', 'Baseline', 'Suppression', 'Rule']);
 
         const resultTableStore1 = new ResultTableStore('File', result => result._relativeUri, resultsSource, filtersSource, selection);
-        assert.deepStrictEqual(resultTableStore1.visibleColumns.map((col) => col.name), ['Line', 'Message']);
+        assert.deepStrictEqual(resultTableStore1.visibleColumns.map((col) => col.name), ['Line', 'Message', 'Suppression', 'Rule']);
 
         const resultTableStore2 = new ResultTableStore('Line', result => result._region?.startLine ?? 0, resultsSource, filtersSource, selection);
-        assert.deepStrictEqual(resultTableStore2.visibleColumns.map((col) => col.name), ['File', 'Message']);
+        assert.deepStrictEqual(resultTableStore2.visibleColumns.map((col) => col.name), ['File', 'Message', 'Suppression', 'Rule']);
 
         const resultTableStore3 = new ResultTableStore('Message', result => result._message, resultsSource, filtersSource, selection);
-        assert.deepStrictEqual(resultTableStore3.visibleColumns.map((col) => col.name), ['Line', 'File']);
+        assert.deepStrictEqual(resultTableStore3.visibleColumns.map((col) => col.name), ['Line', 'File', 'Suppression', 'Rule']);
     });
 
     it.skip('groups the rows and rowItems based the grouping logic applied on resultsSource', () => {

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -44,7 +44,7 @@ declare module 'sarif' {
         _rule?: ReportingDescriptor;
         _message: string; // '—' if empty.
         _markdown?: string;
-        _suppression?: 'not suppressed' | 'suppressed';
+        _suppression?: 'not suppressed' | 'under review' | 'suppressed';
     }
 }
 
@@ -131,7 +131,7 @@ export function augmentLog(log: Log, rules?: Map<string, ReportingDescriptor>, w
             result.baselineState = result.baselineState ?? 'new';
             result._suppression = !result.suppressions || result.suppressions.every(sup => sup.status === 'rejected')
                 ? 'not suppressed'
-                : 'suppressed';
+                : (result.suppressions.every(sup => sup.status === 'underReview') ? 'under review' : 'suppressed');
         });
     });
     log._distinct = mapDistinct(fileAndUris);
@@ -228,6 +228,7 @@ export const filtersRow: Record<string, Record<string, Visibility>> = {
     },
     Suppression: {
         'Not Suppressed': 'visible',
+        'Under Review': 'visible',
         'Suppressed': false,
     },
 };

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -229,15 +229,15 @@ export const filtersRow: Record<string, Record<string, Visibility>> = {
     Suppression: {
         'Not Suppressed': 'visible',
         'Under Review': 'visible',
-        'Suppressed': false,
+        'Suppressed': 'visible',
     },
 };
 
 export const filtersColumn: Record<string, Record<string, Visibility>> = {
     Columns: {
         'Baseline': false,
-        'Suppression': false,
-        'Rule': false,
+        'Suppression': 'visible',
+        'Rule': 'visible',
     },
 };
 


### PR DESCRIPTION
This PR adds support for `Under review` suppressions in SARIF panel.

![image](https://github.com/kubeshop/vscode-sarif/assets/1061942/7e4a9bcc-69e7-444f-a27b-9b1f65837239)

## Changes

- As above.

## Fixes

- Added mechanism to purge locally stored SARIF panel columns/row config (see https://github.com/kubeshop/vscode-sarif/pull/9/commits/7bd38b42c57b520a96e60087e77a5eee0d315bda).

## Remarks

> Added mechanism to purge locally stored SARIF panel columns/row config (see https://github.com/kubeshop/vscode-sarif/pull/9/commits/7bd38b42c57b520a96e60087e77a5eee0d315bda).

This was tricky and I spend more than hour trying to figure out why the changes for columns/row are not shown up. And it turns out the whole config is just stored locally (via `Memento` API, meaning it's preserved between runs) and there is nothing checking if default config structure has changed. I added simple mechanism to just purge the storage when version changes.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
